### PR TITLE
26 bug shell option in cli needs to be optional

### DIFF
--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -26,7 +26,7 @@ pub(crate) struct ConfigFile {
     #[serde(flatten)]
     pub(crate) vars: EnvironmentVariables,
 
-    pub(crate) shell: HashMap<String, EnvironmentVariables>,
+    pub(crate) shell: Option<HashMap<String, EnvironmentVariables>>,
 }
 
 impl ConfigFile {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn get_specific_shell<'a>(
     //! This function's output is meant to be passed into `to_shell_source(...)`.
 
     let field_name = shell.to_possible_value()?.get_name();
-    file_data.shell.get(field_name)
+    file_data.shell.as_ref()?.get(field_name)
 }
 
 fn to_shell_source(vars: &EnvironmentVariables, shell: &Shell) -> String {


### PR DESCRIPTION
Fixes #26.

This is a critical bug and should be merged as soon as possible.