### PR TITLE
Exclude `.github` from `cargo publish`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/superatomic/xshe/"
 keywords = ["cli", "shell", "environment-variable", "configuration", "command"]
 categories = ["command-line-utilities", "config", "parsing"]
 license = "MIT OR Apache-2.0"
+exclude = [".github/"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Fixes #35.