### PR TITLE
Add new form for shell-specific variables and deprecate the old form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +125,22 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "dirs-next"
@@ -228,6 +253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7906a9fababaeacb774f72410e497a1d18de916322e33797bb2cd29baa23c9e"
+dependencies = [
+ "unindent",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +323,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3df761f6470298359f84fcfb60d86db02acc22c251c37265c07a3d1057d2389"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
 ]
 
 [[package]]
@@ -486,6 +541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "unindent"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,7 +608,9 @@ dependencies = [
  "exitcode",
  "human-panic",
  "indexmap",
+ "indoc",
  "log",
+ "pretty_assertions",
  "serde",
  "shellexpand",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ shellexpand = "2.1.0"
 human-panic = "1.0.3"
 log = "0.4.16"
 env_logger = "0.9.0"
+
+[dev-dependencies]
+indoc = "1.0.4"
+pretty_assertions = "1.2.1"

--- a/README.md
+++ b/README.md
@@ -118,18 +118,26 @@ PATH = ["$PATH", "$BIN_HOME", "$CARGO_HOME/bin"]
 
 #### Shell Specific Environment Variables
 
-To set environment variables for only one shell, add a new table called `[shell.NAME]` after all standard definitions,
-where `NAME` is on of `bash`, `zsh`, or `fish`.
-Then list the environment variables that will only be added if `xshe` is being used for the given shell.
+To set environment variables for only one shell, add a `.NAME` prefix after the name of the environment variable,
+where `NAME` is one of `bash`, `zsh`, or `fish`.
+These environment variables will only be added if the given shell is used.
 
-For example, to make `$HISTFILE` be different between shells and `$ZSH_CACHE_DIR` only be set in **zsh**, do this:
+As an example, these lines make `$HISTFILE` be set to different values between different shells,
+and to have `$ZSH_CACHE_DIR` only be set in **zsh**, do this:
+
 ```toml
-[shell.bash]
-HISTFILE = "$XDG_STATE_HOME/bash_history"
+HISTFILE.bash = "$XDG_STATE_HOME/bash_history"
+HISTFILE.zsh = "$XDG_STATE_HOME/zsh_history"
 
-[shell.zsh]
-HISTFILE = "$XDG_STATE_HOME/zsh_history"
-ZSH_CACHE_DIR = "$XDG_CACHE_HOME/oh-my-zsh"
+ZSH_CACHE_DIR.zsh = "$XDG_CACHE_HOME/oh-my-zsh"
+```
+
+You can use `._` instead of using a shell name to specify a default if an option doesn't apply to any of the shells.
+For example, these lines set the `$EDITOR` to `nano` on **bash**, but [`micro`][micro] on everything else:
+
+```toml
+EDITOR.bash = "$(which nano)"
+EDITOR._ = "$(which micro)"
 ```
 
 ### Sourcing the `xshe.toml` file
@@ -272,6 +280,7 @@ additional terms or conditions.
 [Cargo]: https://doc.rust-lang.org/cargo/
 [install Cargo/Rust]: https://www.rust-lang.org/tools/install
 [toml]: https://toml.io/en/
+[micro]: https://micro-editor.github.io/
 
-[example]: https://gist.github.com/superatomic/8f22ada9864c85984d51e0cc6fae4250
+[example]: https://gist.github.com/superatomic/52a46e53a4afce75ede4db7ba6354e0a
 [path?]: https://askubuntu.com/questions/551990/what-does-path-mean

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -50,3 +50,126 @@ pub(crate) enum EnvVariableValue {
     String(String),
     Array(Vec<String>),
 }
+
+#[cfg(test)]
+mod tests {
+    use indexmap::indexmap;
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use EnvVariableOption::*;
+
+    /// A function to get a ConfigFile from a str more easily.
+    fn to_config(toml_str: &str) -> ConfigFile {
+        toml::from_str(toml_str).unwrap()
+    }
+
+    /// Used to compare TOML to its expected representation in all other tests.
+    fn assert_config_value(toml_str: &str, map: EnvironmentVariables) {
+        assert_eq!(to_config(toml_str).vars, map);
+    }
+
+    #[test]
+    fn test_config_file_load_string() {
+        assert_config_value(
+            indoc! {r#"
+                FOO = "Bar"
+            "#},
+            indexmap! {
+                "FOO".into() => General(EnvVariableValue::String("Bar".into())),
+            },
+        )
+    }
+
+    #[test]
+    fn test_config_file_load_path() {
+        assert_config_value(
+            indoc! {r#"
+                PATH = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+            "#},
+            indexmap! {
+                "PATH".into() => General(EnvVariableValue::Array(vec![
+                    "/usr/local/bin".into(),
+                    "/usr/bin".into(),
+                    "/bin".into(),
+                    "/usr/sbin".into(),
+                    "/sbin".into(),
+                ])),
+            },
+        )
+    }
+
+    #[test]
+    fn test_config_file_load_specific() {
+        assert_config_value(
+            indoc! {r#"
+                ONLY_FOR_BASH.bash = "Do people read test cases?"
+            "#},
+            indexmap! {
+                "ONLY_FOR_BASH".into() => Specific(indexmap! {
+                    "bash".into() => EnvVariableValue::String("Do people read test cases?".into()),
+                }),
+            },
+        )
+    }
+
+    #[test]
+    fn test_config_file_load_specific_other() {
+        assert_config_value(
+            indoc! {r#"
+                SOME_VARIABLE.fish = "you're pretty"
+                SOME_VARIABLE._ = '[ACCESS DENIED]'
+            "#},
+            indexmap! {
+                "SOME_VARIABLE".into() => Specific(indexmap! {
+                    "fish".into() => EnvVariableValue::String("you're pretty".into()),
+                    "_".into() => EnvVariableValue::String("[ACCESS DENIED]".into()),
+                })
+            },
+        )
+    }
+
+    #[test]
+    fn test_config_file_load_specific_other_alt() {
+        assert_config_value(
+            indoc! {r#"
+                [SOME_VARIABLE]
+                fish = "you're pretty"
+                _ = '[ACCESS DENIED]'
+                
+                [ANOTHER_VARIABLE]
+                zsh = 'Zzz'
+            "#},
+            indexmap! {
+                "SOME_VARIABLE".into() => Specific(indexmap! {
+                    "fish".into() => EnvVariableValue::String("you're pretty".into()),
+                    "_".into() => EnvVariableValue::String("[ACCESS DENIED]".into()),
+                }),
+                "ANOTHER_VARIABLE".into() => Specific(indexmap! {
+                    "zsh".into() => EnvVariableValue::String("Zzz".into()),
+                }),
+            },
+        )
+    }
+
+    #[test]
+    fn test_config_file_everything() {
+        assert_config_value(
+            indoc! {r#"
+                FOO = 'bar'
+                BAZ.zsh = 'zž'
+                BAZ.fish = ['gone', 'fishing']
+                BAZ._ = 'other'
+            "#},
+            indexmap! {
+                "FOO".into() => General(EnvVariableValue::String("bar".into())),
+                "BAZ".into() => Specific(indexmap! {
+                    "zsh".into() => EnvVariableValue::String("zž".into()),
+                    "fish".into() => EnvVariableValue::Array(vec!["gone".into(), "fishing".into()]),
+                    "_".into() => EnvVariableValue::String("other".into()),
+                })
+            },
+        )
+    }
+}

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -18,15 +18,16 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::string::String;
 
-pub(crate) type EnvironmentVariables = IndexMap<String, EnvValue>;
+pub(crate) type EnvironmentVariables = IndexMap<String, EnvVariableOption>;
 
 /// The TOML file to load environment variables from.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ConfigFile {
     #[serde(flatten)]
     pub(crate) vars: EnvironmentVariables,
 
-    pub(crate) shell: Option<HashMap<String, EnvironmentVariables>>,
+    // Deprecated
+    pub(crate) shell: Option<HashMap<String, IndexMap<String, EnvVariableValue>>>,
 }
 
 impl ConfigFile {
@@ -35,10 +36,17 @@ impl ConfigFile {
     }
 }
 
-/// Enum of possible environment variable value types.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(untagged)]
-pub(crate) enum EnvValue {
+pub(crate) enum EnvVariableOption {
+    Specific(IndexMap<String, EnvVariableValue>),
+    General(EnvVariableValue),
+}
+
+/// Enum of possible environment variable value types.
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(untagged)]
+pub(crate) enum EnvVariableValue {
     String(String),
     Array(Vec<String>),
 }


### PR DESCRIPTION
Closes #30 and introduces changes for #42. <sup>Of course testing code is the meaning of life, the universe, and everything.</sup>