### PR TITLE
Improve CLI `--help` descriptions and change `--toml` to default to `--text`

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,13 +204,13 @@ To specify a custom file that is not located at `~/.config/xshe.toml`, pass the 
 eval "$(xshe zsh --file ~/some/other/location.toml)"
 ```
 
-##### Using `--toml` (or `-t`)
+##### Using `--text` (or `-t`)
 
-To directly specify TOML to parse as a config file, use `--toml`.
+To directly specify TOML to parse as a config file, use `--text`.
 
 For example, this line directly parses the provided line and converts it to zsh:
 ```zsh
-xshe zsh --toml 'BIN_HOME = "$HOME/.local/bin"'
+xshe zsh --text 'BIN_HOME = "$HOME/.local/bin"'
 ```
 
 ##### Using `--pipe` (or `-p`)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,14 +50,14 @@ pub struct Cli {
     pub file: Option<PathBuf>,
 
     #[clap(group = "mode")]
-    #[clap(short, long, value_name = "TOML", value_hint = ValueHint::Other)]
+    #[clap(short, long, value_name = "TOML", visible_alias = "toml", value_hint = ValueHint::Other)]
     /// Directly specify TOML to parse
     ///
     /// The passed string must be in TOML format (https://toml.io/en/).
-    pub toml: Option<String>,
+    pub text: Option<String>,
 
     #[clap(group = "mode")]
-    #[clap(short, long, value_name = "PIPE", visible_alias = "stdin")]
+    #[clap(short, long, value_name = "PIPE", alias = "stdin")]
     #[clap(verbatim_doc_comment)]
     /// Get TOML-formatted data from the standard input
     ///

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,45 +17,55 @@ use clap::{AppSettings, ArgEnum, ArgGroup, Parser, ValueHint};
 use clap_verbosity_flag::{Verbosity, WarnLevel};
 use std::path::PathBuf;
 
-/// CLI Parser.
+// CLI Parser.
 #[derive(Parser)]
 #[clap(group = ArgGroup::new("mode").multiple(false))]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
-#[clap(version, about, long_about = None, arg_required_else_help = true)]
-#[clap(after_help = "Documentation: https://lib.rs/crates/xshe,\n\
-GitHub: https://github.com/superatomic/xshe")]
+#[clap(version, arg_required_else_help = true)]
+#[clap(after_help = "GitHub: https://github.com/superatomic/xshe")]
+/// Cross-Shell Environment Variable Manager
+///
+/// Xshe sets shell environment variables across multiple shells with a single configuration file.
+///
+/// For more, go to https://github.com/superatomic/xshe#readme
 pub struct Cli {
+    /// The shell to generate a script for
+    ///
+    /// Outputs a runnable shell script for the specified shell.
+    ///
+    /// You can directly source these files in your shell.
+    /// Read https://github.com/superatomic/xshe#sourcing-the-xshetoml-file for info.
     #[clap(arg_enum)]
-    #[clap(help = "The shell to generate a script")]
     pub shell: Shell,
 
     #[clap(group = "mode")]
     #[clap(short, long, parse(from_os_str), value_name = "FILE", value_hint = ValueHint::FilePath)]
-    #[clap(help = "Specify a custom location to read from")]
-    #[clap(long_help = "Specifies a custom location to read from\n\
-    This defaults to $XDG_CONFIG_HOME, or ~/.config if not set.\n\
-    \n\
-    Use --pipe or --file=- to pipe from stdin.\n\
-    \n\
-    The file must be in TOML format (https://toml.io/en/).")]
+    /// Specifies a custom location to read from
+    ///
+    /// This defaults to $XDG_CONFIG_HOME, or ~/.config if not set.
+    ///
+    /// Use --pipe or --file=- to pipe from stdin.
+    ///
+    /// The file must be in TOML format (https://toml.io/en/).")
     pub file: Option<PathBuf>,
 
     #[clap(group = "mode")]
     #[clap(short, long, value_name = "TOML", value_hint = ValueHint::Other)]
-    #[clap(help = "Directly specify TOML to parse")]
-    #[clap(long_help = "Directly specify TOML to parse\n\
-    \n\
-    The passed string must be in TOML format (https://toml.io/en/).")]
+    /// Directly specify TOML to parse
+    ///
+    /// The passed string must be in TOML format (https://toml.io/en/).
     pub toml: Option<String>,
 
     #[clap(group = "mode")]
     #[clap(short, long, value_name = "PIPE", visible_alias = "stdin")]
-    #[clap(help = "Get TOML data from standard input")]
-    #[clap(long_help = "Flag to get TOML data from the standard input\n\
-    This is normally used to pass a configuration in from a pipe, like so:\n\
-    \n    cat xshe.toml | xshe bash
-    \n\
-    The passed string must be in TOML format (https://toml.io/en/).")]
+    #[clap(verbatim_doc_comment)]
+    /// Get TOML-formatted data from the standard input
+    ///
+    /// This is normally used to pass a configuration in from a pipe, like so:
+    ///
+    ///     cat xshe.toml | xshe bash
+    ///
+    /// The passed string must be in TOML format (https://toml.io/en/).
     #[clap(takes_value = false)]
     pub pipe: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,9 +71,9 @@ fn main() {
     let (toml_string, file_name) = if pipe {
         // If --pipe was specified, use that as the direct toml.
         (read_stdin(), String::from("<STDIN>"))
-    } else if let Some(toml) = cli_options.toml {
-        // If --toml was specified, use that. Otherwise, get the file and read from it.
-        (toml, String::from("<STRING>"))
+    } else if let Some(text) = cli_options.text {
+        // If --text was specified, use that. Otherwise, get the file and read from it.
+        (text, String::from("<STRING>"))
     } else {
         // Otherwise, read from the chosen file.
         read_config_file(&cli_options)


### PR DESCRIPTION
The CLI `--help` descriptions are now more helpful (and are doc-comments), and the `--toml` option now is named `--text` (but `--toml` can still be used).