### PR TITLE
Add Eget installation method to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ or read the offline documentation in [the `docs/` directory](docs/README.md).
 ## Quick install
 * [With Cargo](docs/install.md#with-cargo)
 * [With Homebrew](docs/install.md#with-homebrew)
+* [With Eget](docs/install.md#with-eget)
 * [As a File Download](docs/install.md#as-a-file-download)
 * [Build from Source](docs/install.md#build-from-source)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ and much more!
 ## Quick install
 * [With Cargo](install.md#with-cargo)
 * [With Homebrew](install.md#with-homebrew)
+* [With Eget](install.md#with-eget)
 * [As a File Download](install.md#as-a-file-download)
 * [Build from Source](install.md#build-from-source)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@ cargo install -f xshe
 
 ### With Homebrew
 
-If you have [Homebrew installed][Homebrew],
+If you have [Homebrew] installed,
 we recommend that you install `xshe` with Homebrew instead of Cargo.
 
 Simply run:
@@ -33,6 +33,16 @@ brew install superatomic/xshe/xshe
 ```
 
 Installing `xshe` with Homebrew adds autocompletion to any shells that have completion enabled.
+
+### With Eget
+
+If you have [Eget] installed, just run:
+
+```shell
+eget superatomic/xshe
+```
+
+This will install a prebuilt binary of `xshe`.
 
 ### As a file download
 
@@ -78,6 +88,7 @@ In this example, `xshe` is installed to `/usr/local/bin`, but `xshe` can anywher
 
 [Homebrew]: https://brew.sh
 [Install Cargo/Rust]: https://www.rust-lang.org/tools/install
+[Eget]: https://github.com/zyedidia/eget
 
 [path?]: https://askubuntu.com/questions/551990/what-does-path-mean
 


### PR DESCRIPTION
Adds the details of how to install `xshe` using [`eget`](https://github.com/zyedidia/eget) to the documentation.