### PR TITLE
Add arrows to documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ or read the offline documentation in [the `docs/` directory](docs/README.md).
 [docs]: https://xshe.superatomic.dev
 
 ## Quick install
-* [With Cargo](docs/install.md#with-cargo)
-* [With Homebrew](docs/install.md#with-homebrew)
-* [With Eget](docs/install.md#with-eget)
-* [As a File Download](docs/install.md#as-a-file-download)
-* [Build from Source](docs/install.md#build-from-source)
+* [With Cargo →](docs/install.md#with-cargo)
+* [With Homebrew →](docs/install.md#with-homebrew)
+* [With Eget →](docs/install.md#with-eget)
+* [As a File Download →](docs/install.md#as-a-file-download)
+* [Build from Source →](docs/install.md#build-from-source)
 
 <div align="center">
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,11 +41,11 @@ and much more!
 
 
 ## Quick install
-* [With Cargo](install.md#with-cargo)
-* [With Homebrew](install.md#with-homebrew)
-* [With Eget](install.md#with-eget)
-* [As a File Download](install.md#as-a-file-download)
-* [Build from Source](install.md#build-from-source)
+* [With Cargo →](install.md#with-cargo)
+* [With Homebrew →](install.md#with-homebrew)
+* [With Eget →](install.md#with-eget)
+* [As a File Download →](install.md#as-a-file-download)
+* [Build from Source →](install.md#build-from-source)
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -80,8 +80,8 @@ Make sure to place the generated binary at `target/release/xshe` on your `PATH`.
 In this example, `xshe` is installed to `/usr/local/bin`, but `xshe` can anywhere on your `PATH`.
 
 # Next steps
-1. [Create an `xshe.toml` file to define your environment variables for every shell.](config_file.md)
-2. [Add `xshe` to the startup script of every shell.](cli.md)
+1. [Create an `xshe.toml` file to define your environment variables for every shell →](config_file.md)
+2. [Add `xshe` to the startup script of every shell →](cli.md)
 
 [crates]: https://crates.io/crates/xshe
 [Cargo]: https://doc.rust-lang.org/cargo/


### PR DESCRIPTION
Adds arrows (`→`) to the end of links in the documentation.
