### PR TITLE
Improve logic for locating the default config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,20 +182,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
@@ -503,15 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
-dependencies = [
- "dirs-next",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +642,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "colored",
+ "dirs",
  "env_logger",
  "exitcode",
  "human-panic",
@@ -661,6 +652,5 @@ dependencies = [
  "maplit",
  "pretty_assertions",
  "serde",
- "shellexpand",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ exitcode = "1.1.2"
 toml = "0.5.9"
 serde = { version = "1.0.137", features = ["derive"] }
 indexmap = { version = "1.9.1", features = ["serde"] }
-shellexpand = "2.1.0"
 human-panic = "1.0.3"
 log = "0.4.17"
 env_logger = "0.9.0"
 colored = "2.0.0"
+dirs = "4.0.0"
 
 [dev-dependencies]
 indoc = "1.0.6"


### PR DESCRIPTION
Removes dependency on [`shellexpand`](https://crates.io/crates/shellexpand), swapping it for manually constructing the correct paths with [`dirs::home_dir()`](https://docs.rs/dirs/4.0.0/dirs/fn.home_dir.html) (using the [`dirs`](https://crates.io/crates/dirs) crate) and [`std::env::var_os(...)`](https://doc.rust-lang.org/std/env/fn.var_os.html).